### PR TITLE
FREEMARKER-1 OverrideResponseContentType init param in FreemarkerServlet

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -54,5 +54,7 @@
 	<classpathentry kind="lib" path="ide-dependencies/jcl-over-slf4j-1.6.1.jar"/>
 	<classpathentry kind="lib" path="ide-dependencies/junit-4.12.jar"/>
 	<classpathentry kind="lib" path="ide-dependencies/hamcrest-library-1.3.jar"/>
+	<classpathentry kind="lib" path="ide-dependencies/spring-core-2.5.6.SEC03.jar"/>
+	<classpathentry kind="lib" path="ide-dependencies/spring-test-2.5.6.SEC03.jar"/>
 	<classpathentry kind="output" path=".bin/"/>
 </classpath>

--- a/ivy.xml
+++ b/ivy.xml
@@ -4,6 +4,7 @@
 <!DOCTYPE ivy-module [
     <!ENTITY jetty.version "7.6.16.v20140903">
     <!ENTITY slf4j.version "1.6.1">
+    <!ENTITY spring.version "2.5.6.SEC03">
 ]>
 <ivy-module version="2.0">
   <info organisation="org.freemarker" module="freemarker">
@@ -137,7 +138,14 @@
       <exclude org="org.slf4j" name="jcl104-over-slf4j" />
       <exclude org="log4j" name="log4j" />
     </dependency>
-    
+
+    <dependency org="org.springframework" name="spring-core" rev="&spring.version;" conf="test->default">
+      <exclude org="commons-logging" name="commons-logging" />
+    </dependency>
+    <dependency org="org.springframework" name="spring-test" rev="&spring.version;" conf="test->default">
+      <exclude org="commons-logging" name="commons-logging" />
+    </dependency>
+
     <!-- docs -->
     
     <dependency org="org.freemarker" name="docgen" rev="2.0-branch-head" conf="manual->default" changing="true" />

--- a/src/main/java/freemarker/ext/servlet/FreemarkerServlet.java
+++ b/src/main/java/freemarker/ext/servlet/FreemarkerServlet.java
@@ -140,7 +140,12 @@ import freemarker.template.utility.StringUtil;
  * actual template file will be used (in the response HTTP header and for encoding the output stream). Note that this
  * setting can be overridden on a per-template basis by specifying a custom attribute named <tt>content_type</tt> in the
  * <tt>attributes</tt> parameter of the <tt>&lt;#ftl&gt;</tt> directive.</li>
- * 
+ *
+ * <li><strong>{@value #INIT_PARAM_OVERRIDE_RESPONSE_CONTENT_TYPE}</strong> (since 2.4.0): If set to true, overrides the ContentType
+ * of the response by using either <strong>{@value #INIT_PARAM_CONTENT_TYPE}</strong> parameter setting or other
+ * information (see the description of <strong>{@value #INIT_PARAM_CONTENT_TYPE}</strong> for detail). The default
+ * value is <tt>false</tt>.</li>
+ *
  * <li><strong>{@value #INIT_PARAM_BUFFER_SIZE}</strong>: Sets the size of the output buffer in bytes, or if "KB" or
  * "MB" is written after the number (like {@code <param-value>256 KB</param-value>}) then in kilobytes or megabytes.
  * This corresponds to {@link HttpServletResponse#setBufferSize(int)}. If the {@link HttpServletResponse} state doesn't
@@ -273,11 +278,18 @@ public class FreemarkerServlet extends HttpServlet {
 
     /**
      * Init-param name - see the {@link FreemarkerServlet} class documentation about the init-params.
+     *
+     * @since 2.4.0
+     */
+    public static final String INIT_PARAM_OVERRIDE_RESPONSE_CONTENT_TYPE = "OverrideResponseContentType";
+
+    /**
+     * Init-param name - see the {@link FreemarkerServlet} class documentation about the init-params.
      * 
      * @since 2.3.22
      */
     public static final String INIT_PARAM_BUFFER_SIZE = "BufferSize";
-    
+
     /**
      * Init-param name - see the {@link FreemarkerServlet} class documentation about the init-params.
      * 
@@ -314,7 +326,7 @@ public class FreemarkerServlet extends HttpServlet {
     private static final String DEPR_INITPARAM_TEMPLATE_EXCEPTION_HANDLER_IGNORE = "ignore";
     private static final String DEPR_INITPARAM_DEBUG = "debug";
     
-    private static final String DEFAULT_CONTENT_TYPE = "text/html";
+    static final String DEFAULT_CONTENT_TYPE = "text/html";
 
     /**
      * When set, the items defined in it will be added after those coming from the
@@ -412,6 +424,7 @@ public class FreemarkerServlet extends HttpServlet {
     @SuppressFBWarnings(value="SE_BAD_FIELD", justification="Not investing into making this Servlet serializable")
     private ObjectWrapper wrapper;
     private String contentType;
+    private boolean overrideResponseContentType = true;
     private boolean noCharsetInContentType;
     private List/*<MetaInfTldSource>*/ metaInfTldSources;
     private List/*<String>*/ classpathTlds;
@@ -557,6 +570,8 @@ public class FreemarkerServlet extends HttpServlet {
                     debug = StringUtil.getYesNo(value);
                 } else if (name.equals(INIT_PARAM_CONTENT_TYPE)) {
                     contentType = value;
+                } else if (name.equals(INIT_PARAM_OVERRIDE_RESPONSE_CONTENT_TYPE)) {
+                    overrideResponseContentType = StringUtil.getYesNo(value);
                 } else if (name.equals(INIT_PARAM_EXCEPTION_ON_MISSING_TEMPLATE)) {
                     exceptionOnMissingTemplate = StringUtil.getYesNo(value);
                 } else if (name.equals(INIT_PARAM_META_INF_TLD_LOCATIONS)) {;
@@ -708,15 +723,17 @@ public class FreemarkerServlet extends HttpServlet {
             throw newServletExceptionWithFreeMarkerLogging(
                     "Unexpected error when loading template " + StringUtil.jQuoteNoXSS(templatePath) + ".", e);
         }
-        
-        Object attrContentType = template.getCustomAttribute("content_type");
-        if (attrContentType != null) {
-            response.setContentType(attrContentType.toString());
-        } else {
-            if (noCharsetInContentType) {
-                response.setContentType(contentType + "; charset=" + template.getEncoding());
+
+        if (overrideResponseContentType) {
+            Object attrContentType = template.getCustomAttribute("content_type");
+            if (attrContentType != null) {
+                response.setContentType(attrContentType.toString());
             } else {
-                response.setContentType(contentType);
+                if (noCharsetInContentType) {
+                    response.setContentType(contentType + "; charset=" + template.getEncoding());
+                } else {
+                    response.setContentType(contentType);
+                }
             }
         }
 

--- a/src/test/java/freemarker/ext/servlet/FreemarkerServletTest.java
+++ b/src/test/java/freemarker/ext/servlet/FreemarkerServletTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package freemarker.ext.servlet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+import freemarker.log.Logger;
+
+public class FreemarkerServletTest {
+
+    private static final Logger LOG = Logger.getLogger("freemarker.servlet");
+
+    private static final String TEST_TEMPLATE_PATH = "classpath:freemarker/ext/servlet";
+
+    private FreemarkerServlet freemarkerServlet;
+
+    private MockServletContext servletContext;
+    private MockServletConfig servletConfig;
+
+    @Before
+    public void setUp() throws ServletException, IOException {
+        servletContext = new MockServletContext();
+        servletContext.setContextPath("/");
+
+        servletConfig = new MockServletConfig(servletContext);
+        servletConfig.addInitParameter(FreemarkerServlet.INIT_PARAM_TEMPLATE_PATH, TEST_TEMPLATE_PATH);
+
+        freemarkerServlet = new FreemarkerServlet();
+        freemarkerServlet.init(servletConfig);
+    }
+
+    @After
+    public void tearDown() {
+        freemarkerServlet.destroy();
+    }
+
+    @Test
+    public void testContentTypeInitParams_withNoResponseContentType_ByDefault() throws ServletException, IOException {
+        MockHttpServletRequest request = createMockHttpServletRequest(servletContext, "/foo.ftl");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        assertNull(response.getContentType());
+
+        freemarkerServlet.doGet(request, response);
+        LOG.debug("response content: " + response.getContentAsString());
+
+        assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+        assertTrue(response.getContentType().contains(FreemarkerServlet.DEFAULT_CONTENT_TYPE));
+    }
+
+    @Test
+    public void testContentTypeInitParams_withResponseContentType_ByDefault() throws ServletException, IOException {
+        MockHttpServletRequest request = createMockHttpServletRequest(servletContext, "/foo.ftl");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setContentType("application/json");
+        assertEquals("application/json", response.getContentType());
+
+        freemarkerServlet.doGet(request, response);
+        LOG.debug("response content: " + response.getContentAsString());
+
+        assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+        assertTrue(response.getContentType().contains(FreemarkerServlet.DEFAULT_CONTENT_TYPE));
+    }
+
+    @Test
+    public void testContentTypeInitParams_withResponseContentType_NoOverriding() throws ServletException, IOException {
+        servletConfig.addInitParameter(FreemarkerServlet.INIT_PARAM_OVERRIDE_RESPONSE_CONTENT_TYPE, "false");
+        freemarkerServlet = new FreemarkerServlet();
+        freemarkerServlet.init(servletConfig);
+
+        MockHttpServletRequest request = createMockHttpServletRequest(servletContext, "/foo.ftl");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setContentType("application/json");
+        assertEquals("application/json", response.getContentType());
+
+        freemarkerServlet.doGet(request, response);
+        LOG.debug("response content: " + response.getContentAsString());
+
+        assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+        assertEquals("application/json", response.getContentType());
+
+        freemarkerServlet.destroy();
+    }
+
+    private MockHttpServletRequest createMockHttpServletRequest(final ServletContext servletContext,
+            final String pathInfo) {
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest(servletContext);
+        servletRequest.setServerName("localhost");
+        servletRequest.setServerPort(8080);
+        servletRequest.setContextPath("");
+        servletRequest.setRequestURI(pathInfo);
+        servletRequest.setPathInfo(pathInfo);
+        return servletRequest;
+    }
+}

--- a/src/test/resources/freemarker/ext/servlet/foo.ftl
+++ b/src/test/resources/freemarker/ext/servlet/foo.ftl
@@ -1,0 +1,19 @@
+<#--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+foo


### PR DESCRIPTION
Added OverrideResponseContentType init param, setting it to true, for backward compatibility.
Also, added a unit test with spring-test dependency (for easier servlet api mocking).
Please take a review. (Once this accepted, FREEMARKER-2 should be easier because of the unit test.)