### PR TITLE
Add OSGI MANIFEST.MF during ide-dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /build.properties
 /archive/
 /ide-dependencies/
+/META-INF
 
 /out/
 /bin/

--- a/README
+++ b/README
@@ -139,7 +139,7 @@ apply it to your development environment:
 
 - Install Ant and Ivy, if you haven't yet; see earlier.
 - From the command line, run `ant clean javacc ide-dependencies`. (Note that
-  now the "ide-dependencies" and  "build/generated-sources" was created.)
+  now the folders "ide-dependencies", "build/generated-sources" and "META-INF" were created.)
 - Start Eclipse
 - You may prefer to start a new workspace (File -> "Switch workspace"), but
   it's optional.

--- a/README
+++ b/README
@@ -138,7 +138,7 @@ different version or an entierly different IDE, still read this, and try to
 apply it to your development environment:
 
 - Install Ant and Ivy, if you haven't yet; see earlier.
-- From the command line, run `ant clean javacc ide-dependencies`. (Note that
+- From the command line, run `ant clean jar javacc ide-dependencies`. (Note that
   now the folders "ide-dependencies", "build/generated-sources" and "META-INF" were created.)
 - Start Eclipse
 - You may prefer to start a new workspace (File -> "Switch workspace"), but

--- a/README
+++ b/README
@@ -138,7 +138,7 @@ different version or an entierly different IDE, still read this, and try to
 apply it to your development environment:
 
 - Install Ant and Ivy, if you haven't yet; see earlier.
-- From the command line, run `ant clean jar javacc ide-dependencies`. (Note that
+- From the command line, run `ant clean jar ide-dependencies`. (Note that
   now the folders "ide-dependencies", "build/generated-sources" and "META-INF" were created.)
 - Start Eclipse
 - You may prefer to start a new workspace (File -> "Switch workspace"), but

--- a/build.xml
+++ b/build.xml
@@ -1067,6 +1067,15 @@ Proceed? </input>
       </fileset>  
     </delete>    
     <ivy:retrieve conf="IDE" pattern="ide-dependencies/[artifact]-[revision].[ext]" />
+
+    <!-- Extract META-INF from freemarker.jar and put it in base directory for eclipse 
+    (this is needed if you want to reference freemarker-source code in the context of OSGI development with Eclipse) -->
+    <unzip src="build/freemarker.jar" dest=".">
+      <patternset>
+        <include name="META-INF/*"/>
+      </patternset>
+    </unzip>
+
   </target>
   
   <!--

--- a/build.xml
+++ b/build.xml
@@ -1068,7 +1068,7 @@ Proceed? </input>
     </delete>    
     <ivy:retrieve conf="IDE" pattern="ide-dependencies/[artifact]-[revision].[ext]" />
 
-    <!-- Extract META-INF from freemarker.jar and put it in base directory for eclipse 
+    <!-- Extract META-INF folder with files like MANIFEST.MF from freemarker.jar and put it in base directory for eclipse 
     (this is needed if you want to reference freemarker-source code in the context of OSGI development with Eclipse) -->
     <unzip src="build/freemarker.jar" dest=".">
       <patternset>

--- a/build.xml
+++ b/build.xml
@@ -105,6 +105,7 @@
   
   <target name="clean" description="get rid of all generated files">
     <delete dir="build" />
+    <delete dir="META-INF" />
   </target>
 
   <target name="clean-classes" description="get rid of compiled classes">


### PR DESCRIPTION
Hi Daniel,
as discussed in https://www.mail-archive.com/dev@freemarker.incubator.apache.org/msg00687.html I finally found time to commit the changes. 

Basically what the 4 commits are doing:

1. during build of target ide-dependencies the META-INF folder inside generated freemarker.jar is extracted
2. for that I adjusted the build.xml and README to point out this change. The ide-dependencies target now requires the freemarker.jar to be present. before it was not needed. 

**Why is this useful?** 

Because I need the META-INF/MANIFEST.MF in my Eclipse / OSGI at **development time** so that other bundles in the same Eclipse workspace  recognize my Freemarker Workspace project (which I imported before based on the README description).

In our company we have a Eclipse / OSGI product and we would like to include the Freemarker source code project directly in eclipse. This makes it much easier to contribute to Freemarker, because we can directly test it during our own development. 

Best regards,
Christoph