### PR TITLE
Workaround for classpath resource concurrent access issue

### DIFF
--- a/src/main/java/freemarker/ext/beans/UnsafeMethods.java
+++ b/src/main/java/freemarker/ext/beans/UnsafeMethods.java
@@ -21,6 +21,7 @@ package freemarker.ext.beans;
 
 import java.io.InputStream;
 import java.lang.reflect.Method;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -44,13 +45,15 @@ class UnsafeMethods {
     
     private static final Set createUnsafeMethodsSet() {
         Properties props = new Properties();
-        InputStream in = BeansWrapper.class.getResourceAsStream("unsafeMethods.properties");
-        if (in == null) {
+
+        URL unsafeMethodsResource = BeansWrapper.class.getResource("unsafeMethods.properties");
+        if (unsafeMethodsResource == null) {
             throw new IllegalStateException("Class loader resource not found: "
                         + BeansWrapper.class.getPackage().getName() + UNSAFE_METHODS_PROPERTIES);
         }
         String methodSpec = null;
         try {
+            InputStream in = unsafeMethodsResource.openStream();
             try {
                 props.load(in);
             } finally {

--- a/src/main/java/freemarker/template/Configuration.java
+++ b/src/main/java/freemarker/template/Configuration.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
 import java.net.URLConnection;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
@@ -436,11 +437,12 @@ public class Configuration extends Configurable implements Cloneable, ParserConf
     static {
         try {
             Properties vp = new Properties();
-            InputStream ins = Configuration.class.getClassLoader()
-                    .getResourceAsStream(VERSION_PROPERTIES_PATH);
-            if (ins == null) {
+            URL versionPropertiesResource = Configuration.class.getClassLoader()
+                    .getResource(VERSION_PROPERTIES_PATH);
+            if (versionPropertiesResource == null) {
                 throw new RuntimeException("Version file is missing.");
             } else {
+                InputStream ins = versionPropertiesResource.openStream();
                 try {
                     vp.load(ins);
                 } finally {


### PR DESCRIPTION
getResourceAsStream() is not equivalent to getResource() + openStream().
In concurrent env. the former sometimes returns and already closed
stream.

This is a workaround for the following issue we are encountering when using Freemarker for annotation processing in parallel maven build (-T). This is unfortunately just a workaround and such is not ideal, so fell free to reject this.

The stacktrace of the error:
```
18:44:24 [ERROR] /home/jenkins/workspace/guvnor/upstream-repos/uberfire/uberfire-showcase/uberfire-client-webapp/src/main/java/org/uberfire/client/screens/DemoSplashScreen.java:[34,1] Internal error in org.uberfire.annotations.processors.WorkbenchSplashScreenProcessorjava.lang.ExceptionInInitializerError
18:44:24 [ERROR] at org.uberfire.annotations.processors.AbstractGenerator.<init>(AbstractGenerator.java:44)
18:44:24 [ERROR] at org.uberfire.annotations.processors.SplashScreenActivityGenerator.<init>(SplashScreenActivityGenerator.java:41)
18:44:24 [ERROR] at org.uberfire.annotations.processors.WorkbenchSplashScreenProcessor.<init>(WorkbenchSplashScreenProcessor.java:49)
18:44:24 [ERROR] at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
....
18:44:24 [ERROR] at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
18:44:24 [ERROR] at java.lang.Thread.run(Thread.java:745)
18:44:24 [ERROR] Caused by: java.lang.IllegalStateException: zip file closed
18:44:24 [ERROR] at java.util.zip.ZipFile.ensureOpen(ZipFile.java:669)
18:44:24 [ERROR] at java.util.zip.ZipFile.getEntry(ZipFile.java:309)
18:44:24 [ERROR] at java.util.jar.JarFile.getEntry(JarFile.java:240)
18:44:24 [ERROR] at sun.net.www.protocol.jar.URLJarFile.getEntry(URLJarFile.java:128)
18:44:24 [ERROR] at sun.net.www.protocol.jar.JarURLConnection.connect(JarURLConnection.java:132)
18:44:24 [ERROR] at sun.net.www.protocol.jar.JarURLConnection.getInputStream(JarURLConnection.java:150)
18:44:24 [ERROR] at java.net.URLClassLoader.getResourceAsStream(URLClassLoader.java:238)
18:44:24 [ERROR] at freemarker.template.Configuration.<clinit>(Configuration.java:431)
```

After applying the workaround we never saw that exception again (with several hundreds of builds).