### PR TITLE
emphasize difference between eval and interpret built-ins in the documentation

### DIFF
--- a/src/manual/en_US/book.xml
+++ b/src/manual/en_US/book.xml
@@ -18030,7 +18030,7 @@ Sorted by name.last:
             <primary>evaluate string</primary>
           </indexterm>
 
-          <para>This built-in evaluates a string as an FTL expression. For
+          <para>This built-in evaluates a string as an FTL <emphasis>expression</emphasis>. For
           example <literal>"1+2"?eval</literal> returns number 3.</para>
 
           <para>The evaluated expression sees the same variables (such as
@@ -18041,7 +18041,11 @@ Sorted by name.last:
           <literal><replaceable>s</replaceable></literal> there. Except, it
           can't use <link linkend="ref_builtins_loop_var">loop variable
           built-ins</link> that refer to a loop variable that was created
-          outside <literal><replaceable>s</replaceable></literal>.</para>
+          outside <literal><replaceable>s</replaceable></literal>.
+          Please note that the string accepts an expression, if you want to
+          render out a full-fledged template, please use the 
+          <link linkend="ref_builtin_interpret"><literal>interpret</literal>
+          built-in.</para>
 
           <para>Regarding the configuration settings that affect the parsing
           (like syntax) and evaluation the rules are the same as with the


### PR DESCRIPTION
I have been struggling with the eval and interpret built-ins, and during this I learned an essential difference between the two is that eval only evaluates expressions, and interpret accepts full-fledged templates as their input strings.

Therefore I would like to add this information to the documentation, such that others realize this sooner and find even more ease and enjoyment in using freemarker :)